### PR TITLE
Base PACKAGE_ID on package name

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ import path from "path";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 
-const PACKAGE_ID = "modules/dfreds-module-template-ts";
+const PACKAGE_ID = `modules/${packageJSON.name}`;
 
 const config = Vite.defineConfig(({ command, mode }): Vite.UserConfig => {
     const buildMode =


### PR DESCRIPTION
Read package name from `package.json` so it only has to be changed in a single place when the template is used